### PR TITLE
Rewrote tokenizer into procedural style for efficiency

### DIFF
--- a/src/Tokenizer.php
+++ b/src/Tokenizer.php
@@ -14,37 +14,6 @@ use function substr;
 final class Tokenizer
 {
     /**
-     * @var string $message The message that we are tokenizing.
-     */
-    private $message;
-
-    /**
-     * @var int The current position in the message.
-     */
-    private $position = 0;
-
-    /**
-     * @var ControlCharactersInterface $character The control characters for the message.
-     */
-    private $characters;
-
-    /**
-     * @var string $char The current character from the message we are dealing with.
-     */
-    private $char = "";
-
-    /**
-     * @var string $string The stored characters for the next token.
-     */
-    private $string;
-
-    /**
-     * @var bool $isEscaped If the current character has been esacped.
-     */
-    private $isEscaped = false;
-
-
-    /**
      * Convert the passed message into tokens.
      *
      * @param string $message The EDI message
@@ -55,167 +24,57 @@ final class Tokenizer
      */
     public function getTokens(string $message, ControlCharactersInterface $characters): array
     {
-        $this->message = $message;
-        $this->characters = $characters;
-        $this->char = "";
-        $this->string = "";
+        $escapeCharacter = $characters->getEscapeCharacter();
+        $componentSeparator = $characters->getComponentSeparator();
+        $dataSeparator = $characters->getDataSeparator();
+        $segmentTerminator = $characters->getSegmentTerminator();
 
-        $this->readNextChar();
-
+        $position = 0;
+        $size = strlen($message);
         $tokens = [];
-        while ($token = $this->getNextToken()) {
-            $tokens[] = $token;
+        $buffer = "";
+        $isEscaped = false;
+        while ($position < $size) {
+            $char = substr($message, $position, 1);
+
+            if ($isEscaped) {
+                $isEscaped = false;
+                $buffer .= $char;
+            } elseif ($char === $componentSeparator) {
+                if (strlen($buffer) !== 0) {
+                    $tokens[] = new Token(Token::CONTENT, $buffer);
+                    $buffer = "";
+                }
+                $tokens[] = new Token(Token::COMPONENT_SEPARATOR, $char);
+            } elseif ($char === $dataSeparator) {
+                if (strlen($buffer) !== 0) {
+                    $tokens[] = new Token(Token::CONTENT, $buffer);
+                    $buffer = "";
+                }
+                $tokens[] = new Token(Token::DATA_SEPARATOR, $char);
+            } elseif ($char === $segmentTerminator) {
+                if (strlen($buffer) !== 0) {
+                    $tokens[] = new Token(Token::CONTENT, $buffer);
+                    $buffer = "";
+                }
+                $tokens[] = new Token(Token::TERMINATOR, $char);
+
+                while (in_array(substr($message, $position + 1, 1), ["\r", "\n"], true)) {
+                    ++$position;
+                }
+            } elseif ($char === $escapeCharacter) {
+                $isEscaped = true;
+            } else {
+                $buffer .= $char;
+            }
+
+            ++$position;
+        }
+
+        if (strlen($buffer) !== 0 || $isEscaped) {
+            throw new ParseException("Unexpected end of EDI message");
         }
 
         return $tokens;
-    }
-
-
-    /**
-     * Read the next character from the message.
-     *
-     * @return void
-     */
-    private function readNextChar(): void
-    {
-        $this->char = $this->getNextChar();
-
-        # If the last character was escaped, this one can't possibly be
-        if ($this->isEscaped) {
-            $this->isEscaped = false;
-        }
-
-        # If this is the escape character, then read the next one and flag the next as escaped
-        if ($this->char === $this->characters->getEscapeCharacter()) {
-            $this->char = $this->getNextChar();
-            $this->isEscaped = true;
-        }
-    }
-
-
-    /**
-     * Get the next character from the message.
-     *
-     * @return string
-     */
-    private function getNextChar(): string
-    {
-        $char = substr($this->message, $this->position, 1);
-        ++$this->position;
-
-        return $char;
-    }
-
-
-    /**
-     * Get the next token from the message.
-     *
-     * @return Token|null
-     * @throws ParseException
-     */
-    private function getNextToken(): ?Token
-    {
-        if ($this->endOfMessage()) {
-            return null;
-        }
-
-        # If we're not escaping this character then see if it's a control character
-        if (!$this->isEscaped) {
-            if ($this->char === $this->characters->getComponentSeparator()) {
-                $this->storeCurrentCharAndReadNext();
-                return new Token(Token::COMPONENT_SEPARATOR, $this->extractStoredChars());
-            }
-
-            if ($this->char === $this->characters->getDataSeparator()) {
-                $this->storeCurrentCharAndReadNext();
-                return new Token(Token::DATA_SEPARATOR, $this->extractStoredChars());
-            }
-
-            if ($this->char === $this->characters->getSegmentTerminator()) {
-                $this->storeCurrentCharAndReadNext();
-                $token = new Token(Token::TERMINATOR, $this->extractStoredChars());
-
-                # Ignore any trailing space after the end of the segment
-                while (in_array($this->char, ["\r", "\n"], true)) {
-                    $this->readNextChar();
-                }
-
-                return $token;
-            }
-        }
-
-        while (!$this->isControlCharacter()) {
-            if ($this->endOfMessage()) {
-                throw new ParseException("Unexpected end of EDI message");
-            }
-            $this->storeCurrentCharAndReadNext();
-        }
-
-        return new Token(Token::CONTENT, $this->extractStoredChars());
-    }
-
-
-    /**
-     * Check if the current character is a control character.
-     *
-     * @return bool
-     */
-    private function isControlCharacter(): bool
-    {
-        if ($this->isEscaped) {
-            return false;
-        }
-
-        if ($this->char === $this->characters->getComponentSeparator()) {
-            return true;
-        }
-
-        if ($this->char === $this->characters->getDataSeparator()) {
-            return true;
-        }
-
-        if ($this->char === $this->characters->getSegmentTerminator()) {
-            return true;
-        }
-
-        return false;
-    }
-
-
-    /**
-     * Store the current character and read the next one from the message.
-     *
-     * @return void
-     */
-    private function storeCurrentCharAndReadNext(): void
-    {
-        $this->string .= $this->char;
-        $this->readNextChar();
-    }
-
-
-    /**
-     * Get the previously stored characters.
-     *
-     * @return string
-     */
-    private function extractStoredChars(): string
-    {
-        $string = $this->string;
-
-        $this->string = "";
-
-        return $string;
-    }
-
-
-    /**
-     * Check if we've reached the end of the message
-     *
-     * @return bool
-     */
-    private function endOfMessage(): bool
-    {
-        return strlen($this->char) == 0;
     }
 }


### PR DESCRIPTION
I went ahead and rewrote the tokenizer for performance. This improves performance considerably, going from a baseline of 4.717s to 1.921s on a large file. Memory footprint is the same.

I also tried using preg for tokenization, but this didn't really improve the results. I suspect this is because most source files consists of many small single-char tokens.

Since this is a complete rewrite of core code, it should probably be tested in depth before merging.