### PR TITLE
Allow to inject serializer into message

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -16,6 +16,13 @@ final class Message implements MessageInterface
      */
     private $segments = [];
 
+    private SerializerInterface $serializer;
+
+    public function __construct(SerializerInterface $serializer = null)
+    {
+        $this->serializer = $serializer ?? new Serializer();
+    }
+
 
     /**
      * Create a new instance from a file.
@@ -148,7 +155,7 @@ final class Message implements MessageInterface
      */
     public function serialize(): string
     {
-        return (new Serializer())->serialize(...$this->getAllSegments());
+        return $this->serializer->serialize(...$this->getAllSegments());
     }
 
 


### PR DESCRIPTION
Moved serializer to constructor in order to allow to override it.

This allows to inject a custom serializer instance, with f.e. configured different characters.

In my case I needed to use '.' as a decimal separator, it is not possible without the above change (or skipping the message->serialize method).