### PR TITLE
add support for php 8.4: explicit nullables

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -18,6 +18,7 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4"
         composer:
           - ""
           - "--prefer-lowest"

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -36,7 +36,7 @@ final class Parser implements ParserInterface
      *
      * @param FactoryInterface $factory A segment factory for creating segments
      */
-    public function __construct(FactoryInterface $factory = null, TokenizerInterface $tokenizer = null)
+    public function __construct(?FactoryInterface $factory = null, ?TokenizerInterface $tokenizer = null)
     {
         if ($factory === null) {
             $factory = new Factory();
@@ -59,7 +59,7 @@ final class Parser implements ParserInterface
      * @return SegmentInterface[]
      * @throws ParseException
      */
-    public function parse(string $message, ControlCharactersInterface $characters = null): iterable
+    public function parse(string $message, ?ControlCharactersInterface $characters = null): iterable
     {
         $characters = $this->getControlCharacters($message, $characters);
 
@@ -79,7 +79,7 @@ final class Parser implements ParserInterface
      *
      * @return ControlCharactersInterface
      */
-    private function getControlCharacters(string &$message, ControlCharactersInterface $characters = null): ControlCharactersInterface
+    private function getControlCharacters(string &$message, ?ControlCharactersInterface $characters = null): ControlCharactersInterface
     {
         if ($characters === null) {
             $characters = new ControlCharacters();

--- a/src/ParserInterface.php
+++ b/src/ParserInterface.php
@@ -17,5 +17,5 @@ interface ParserInterface
      * @return iterable<SegmentInterface>
      * @throws ParseException
      */
-    public function parse(string $message, ControlCharactersInterface $characters = null): iterable;
+    public function parse(string $message, ?ControlCharactersInterface $characters = null): iterable;
 }

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -25,7 +25,7 @@ final class Serializer implements SerializerInterface
     /**
      * @param ControlCharactersInterface|null $characters
      */
-    public function __construct(ControlCharactersInterface $characters = null)
+    public function __construct(?ControlCharactersInterface $characters = null)
     {
         if ($characters === null) {
             $characters = new ControlCharacters();

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -29,7 +29,7 @@ class ParserTest extends TestCase
     }
 
 
-    public function getControlCharacters(string &$message, ControlCharactersInterface $characters = null): void
+    public function getControlCharacters(string &$message, ?ControlCharactersInterface $characters = null): void
     {
         if ($characters === null) {
             $characters = Mockery::mock(ControlCharactersInterface::class);


### PR DESCRIPTION
php 8.4 deprecates implicit nullability for parameters: https://www.php.net/manual/en/migration84.deprecated.php

So `function a(string $foo = null)` will throw a deprecation notice, the parameter must explicitly be marked nullable `function a(?string $foo = null)`.

It this is merged (assuming it works correct... i hope!) a new release would be appreciated. 