### PR TITLE
Feature/performance change: lazy parsing

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -114,7 +114,7 @@ final class Parser implements ParserInterface
      *
      * @return iterable&SegmentInterface[]
      */
-    private function convertTokensToSegments(array $tokens, ControlCharactersInterface $characters): iterable
+    private function convertTokensToSegments(iterable $tokens, ControlCharactersInterface $characters): iterable
     {
         $segments = [];
         $currentSegment = -1;

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -112,12 +112,11 @@ final class Parser implements ParserInterface
      * @param Token[] $tokens The tokens that make up the message
      * @param ControlCharactersInterface $characters The control characters
      *
-     * @return iterable&SegmentInterface[]
+     * @return iterable<SegmentInterface>
      */
     private function convertTokensToSegments(iterable $tokens, ControlCharactersInterface $characters): iterable
     {
-        $segments = [];
-        $currentSegment = -1;
+        $currentSegment = null;
         $inSegment = false;
 
         $part = 0;
@@ -132,9 +131,11 @@ final class Parser implements ParserInterface
 
             # If we're not in a segment, then start a new one now
             } else {
+                if ($currentSegment !== null) {
+                    yield $this->produceSegment($currentSegment, $characters);
+                }
                 $inSegment = true;
-                $currentSegment++;
-                $segments[$currentSegment] = [];
+                $currentSegment = [];
                 $part = 0;
                 $key = 0;
             }
@@ -166,15 +167,15 @@ final class Parser implements ParserInterface
              */
             if ($part > 0) {
                 for ($i = 0; $i < $part; $i++) {
-                    if (!isset($segments[$currentSegment][$i])) {
-                        $segments[$currentSegment][$i] = "";
+                    if (!isset($currentSegment[$i])) {
+                        $currentSegment[$i] = "";
                     }
                 }
             }
 
             # If this is the first element within the part then just set it as a string.
             if ($key === 0) {
-                $segments[$currentSegment][$part] = $token->value;
+                $currentSegment[$part] = $token->value;
                 continue;
             }
 
@@ -186,23 +187,33 @@ final class Parser implements ParserInterface
                 $value = ($i === $key) ? $token->value : "";
 
                 # If there is an initial element set as a string, we need to convert it into an array before we append to it
-                if (isset($segments[$currentSegment][$part]) && !is_array($segments[$currentSegment][$part])) {
-                    $segments[$currentSegment][$part] = [$segments[$currentSegment][$part]];
+                if (isset($currentSegment[$part]) && !is_array($currentSegment[$part])) {
+                    $currentSegment[$part] = [$currentSegment[$part]];
                 }
 
                 # If this part does not exist, set it now
-                if (!isset($segments[$currentSegment][$part][$i])) {
-                    $segments[$currentSegment][$part][$i] = $value;
+                if (!isset($currentSegment[$part][$i])) {
+                    $currentSegment[$part][$i] = $value;
                 }
             }
         }
 
-        foreach ($segments as $segment) {
-            $code = array_shift($segment);
-            if (!is_string($code)) {
-                throw new ParseException("Invalid segment encountered, first element should be the name");
-            }
-            yield $this->factory->createSegment($characters, $code, ...$segment);
+        if ($currentSegment !== []) {
+            yield $this->produceSegment($currentSegment, $characters);
         }
+    }
+
+    /**
+     * @param array<string> $elements
+     * @throws ParseException if the first element is not a string
+     */
+    private function produceSegment(array $elements, ControlCharactersInterface $characters): SegmentInterface
+    {
+        $code = array_shift($elements);
+        if (!is_string($code)) {
+            throw new ParseException("Invalid segment encountered, first element should be the name");
+        }
+
+        return $this->factory->createSegment($characters, $code, ...$elements);
     }
 }

--- a/src/Tokenizer.php
+++ b/src/Tokenizer.php
@@ -51,10 +51,10 @@ final class Tokenizer implements TokenizerInterface
      * @param string $message The EDI message
      * @param ControlCharactersInterface $characters
      *
-     * @return Token[]
+     * @return iterable<Token>
      * @throws ParseException
      */
-    public function getTokens(string $message, ControlCharactersInterface $characters): array
+    public function getTokens(string $message, ControlCharactersInterface $characters): iterable
     {
         $this->message = $message;
         $this->position = 0;
@@ -65,12 +65,9 @@ final class Tokenizer implements TokenizerInterface
 
         $this->readNextChar();
 
-        $tokens = [];
         while ($token = $this->getNextToken()) {
-            $tokens[] = $token;
+            yield $token;
         }
-
-        return $tokens;
     }
 
 

--- a/src/TokenizerInterface.php
+++ b/src/TokenizerInterface.php
@@ -13,8 +13,8 @@ interface TokenizerInterface
     /**
      * Convert the passed message into tokens.
      *
-     * @return Token[]
+     * @return iterable<Token>
      * @throws ParseException
      */
-    public function getTokens(string $message, ControlCharactersInterface $characters): array;
+    public function getTokens(string $message, ControlCharactersInterface $characters): iterable;
 }

--- a/tests/TokenizerTest.php
+++ b/tests/TokenizerTest.php
@@ -27,7 +27,7 @@ class TokenizerTest extends TestCase
      */
     private function assertTokens(string $message, array $expected): void
     {
-        $tokens = $this->tokenizer->getTokens("{$message}'", new ControlCharacters());
+        $tokens = iterator_to_array($this->tokenizer->getTokens("{$message}'", new ControlCharacters()));
 
         $expected[] = new Token(Token::TERMINATOR, "'");
 
@@ -127,6 +127,6 @@ class TokenizerTest extends TestCase
     {
         $this->expectException(ParseException::class);
         $this->expectExceptionMessage("Unexpected end of EDI message");
-        $this->tokenizer->getTokens("TEST", new ControlCharacters());
+        $this->tokenizer->getTokens("TEST", new ControlCharacters())->next();
     }
 }


### PR DESCRIPTION
We ran into a problem when parsing somewhat sizable EDI files (>25MB) because the parser already broke our 2GB memory limit.

After a bit of fiddling it turned out that the buffering the parser does while in the Tokenizer as well as in `convertTokensToSegments` is quite heavy on the memory. For our 26MB test file the `getTokens` buffer alone added about 1650 MB to the memory, which would not be released until after all segments have been produced. The OOM then broken soon somewhere in `convertTokensToSegments`. 

Since the `convertTokensToSegments` already returns a generator I extended that concept. TokenizerInterface now returns a iterable, and yields tokens on demand. 

`convertTokensToSegments` consumes this generator, pulls tokens on demand, and, instead of first collecting all segments and then yielding them when done, it immediately yields a segment before starting to read the next one. 

This allows the consumer to start processing segments pretty much instantly and moves the whole overhad for the Parser from ~90xFilesize to ~1xFilesize. 

In my tests this improves parsing time for large files by ~20%, since very little time is spend on memory allocation. 

Here are some numbers of benchmarks I ran for this: 
```
# first the current main branch
> php -dmemory_limit=6G bench.php  AN_UNGODLY_AMOUNT_OF_EDI
current memory:     27.0 MB| peak memory:     27.1 MB | after reading file
current memory:    187.9 MB| peak memory:  2,412.9 MB | after parsing all segments
parsing all segments took 10787 ms

### next with just the first commit, changing Tokenizer
# again 3 runs to check for variance
> php -dmemory_limit=6G bench.php  AN_UNGODLY_AMOUNT_OF_EDI
current memory:     27.1 MB| peak memory:     27.1 MB | after reading file
current memory:     53.7 MB| peak memory:    833.7 MB | after parsing all segments
parsing all segments took 9173 ms
> php -dmemory_limit=6G bench.php  AN_UNGODLY_AMOUNT_OF_EDI
current memory:     27.0 MB| peak memory:     27.1 MB | after reading file
current memory:     53.7 MB| peak memory:    833.7 MB | after parsing all segments
parsing all segments took 8892 ms
> php -dmemory_limit=6G bench.php  AN_UNGODLY_AMOUNT_OF_EDI
current memory:     27.0 MB| peak memory:     27.1 MB | after reading file
current memory:     53.7 MB| peak memory:    833.7 MB | after parsing all segments
parsing all segments took 9026 ms

### and this is both changes together
# again 3 runs to check for variance
> php -dmemory_limit=6G bench.php  AN_UNGODLY_AMOUNT_OF_EDI
current memory:     27.0 MB| peak memory:     27.1 MB | after reading file
current memory:     53.7 MB| peak memory:     53.7 MB | after parsing all segments
parsing all segments took 8419 ms
> php -dmemory_limit=6G bench.php  AN_UNGODLY_AMOUNT_OF_EDI
current memory:     27.0 MB| peak memory:     27.1 MB | after reading file
current memory:     53.7 MB| peak memory:     53.7 MB | after parsing all segments
parsing all segments took 8211 ms
> php -dmemory_limit=6G bench.php  AN_UNGODLY_AMOUNT_OF_EDI
current memory:     27.0 MB| peak memory:     27.1 MB | after reading file
current memory:     53.7 MB| peak memory:     53.7 MB | after parsing all segments
parsing all segments took 8316 ms
```

The phpunit performance test showed no signicant change in performance for me.


And heres bench.php, so you see whats benchmarked:

```php
<?php

require_once __DIR__ . '/vendor/autoload.php';

$parser = new \Estrato\Edifact\Parser();
$data = file_get_contents($argv[1]);

printf(
    "current memory: %8s MB| peak memory: %8s MB | after reading file\n",
    number_format(memory_get_usage() / 1_000_000, 1),
    number_format(memory_get_peak_usage() / 1_000_000, 1)
);

$start = microtime(true);
foreach ($parser->parse($data) as $segment) {
    // do something clever with segment but forget it ASAP
}
$duration = microtime(true) - $start;

printf(
    "current memory: %8s MB| peak memory: %8s MB | after parsing all segments\n",
    number_format(memory_get_usage() / 1_000_000, 1),
    number_format(memory_get_peak_usage() / 1_000_000, 1)
);

printf("parsing all segments took %d ms\n", (int)($duration * 1000));

```

I am aware that this hides a crucial stop: somehow somewhere has do something with these segments and certainly would want to buffer some of them. 
My experience, at least for other application, is that whatever the consumer does with that segments uses less memory. Also they may also comsume them in a lazy iterative fashin, e.g. processing a full message before starting the next one. So peak memory can be lowered by this, which is what we wanted to achive.

## BC Break: 
I think this - if accepted - requires releasing a new major version, since the TokenizerInterface::getToken changes return type in an incompatible way. 